### PR TITLE
Updated logic related to use RangeTree 2.0.1

### DIFF
--- a/GeneralAlgorithms.Tests/GeneralAlgorithms.Tests.csproj
+++ b/GeneralAlgorithms.Tests/GeneralAlgorithms.Tests.csproj
@@ -13,9 +13,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeneralAlgorithms\GeneralAlgorithms.csproj" />

--- a/GeneralAlgorithms/Algorithms/Polygons/GridPolygonPartitioning.cs
+++ b/GeneralAlgorithms/Algorithms/Polygons/GridPolygonPartitioning.cs
@@ -87,9 +87,14 @@
 				from.Next = to;
 				to.Prev = from;
 			}
+
+			var horizontalTree = new RangeTree<int, Segment>();
+			foreach (var segment in horizontalSegments)
+				horizontalTree.Add(segment.Range.X, segment.Range.Y, segment);
 			
-			var horizontalTree = new RangeTree<int, Segment>(horizontalSegments, new SegmentComparer());
-			var verticalTree = new RangeTree<int, Segment>(verticalSegments, new SegmentComparer());
+			var verticalTree = new RangeTree<int, Segment>();
+			foreach (var segment in verticalSegments)
+				verticalTree.Add(segment.Range.X, segment.Range.Y, segment);
 
 			//Find horizontal and vertical diagonals
 			var horizontalDiagonals = GetDiagonals(vertices, verticalTree, false);
@@ -180,8 +185,13 @@
 				}
 			}
 
-			var leftTree = new RangeTree<int, Segment>(leftSegments, new SegmentComparer());
-			var rightTree = new RangeTree<int, Segment>(rightSegments, new SegmentComparer());
+			var leftTree = new RangeTree<int, Segment>();
+			foreach (var segment in leftSegments)
+				leftTree.Add(segment.Range.X, segment.Range.Y, segment);
+
+			var rightTree = new RangeTree<int, Segment>();
+			foreach (var segment in rightSegments)
+				rightTree.Add(segment.Range.X, segment.Range.Y, segment);
 
 			var i = 0;
 			while (i < vertices.Count)
@@ -258,9 +268,13 @@
 				}
 
 				tree.Remove(closestSegment);
-				tree.Add(new Segment(closestSegment.From, splitA, false));
-				tree.Add(new Segment(splitB, closestSegment.To, false));
 
+				var segmentSplitA = new Segment(closestSegment.From, splitA, false);
+				tree.Add(segmentSplitA.Range.X, segmentSplitA.Range.Y, segmentSplitA);
+				
+				var segmentSplitB = new Segment(splitB, closestSegment.To, false);
+				tree.Add(segmentSplitB.Range.X, segmentSplitB.Range.Y, segmentSplitB);
+				
 				vertices.Add(splitA);
 				vertices.Add(splitB);
 
@@ -548,7 +562,9 @@
 				return new List<Tuple<Segment, Segment>>();
 			}
 
-			var horizontalTree = new RangeTree<int, Segment>(horizontalDiagonals, new SegmentComparer());
+			var horizontalTree = new RangeTree<int, Segment>();
+			foreach (var segment in horizontalDiagonals)
+				horizontalTree.Add(segment.Range.X, segment.Range.Y, segment);
 			var crosssings = new List<Tuple<Segment, Segment>>();
 
 			foreach (var v in verticalDiagonals)
@@ -596,14 +612,14 @@
 			}
 		}
 
-		private class Segment : IRangeProvider<int>
+		private class Segment
 		{
 			public readonly Vertex From;
 			public readonly Vertex To;
 			public readonly bool Horizontal;
 			public int Number;
 
-			public Range<int> Range { get; }
+			public IntVector2 Range { get; }
 
 			public Segment(Vertex from, Vertex to, bool horizontal)
 			{
@@ -613,11 +629,11 @@
 
 				if (horizontal)
 				{
-					Range = new Range<int>(Math.Min(from.Point.X, to.Point.X), Math.Max(from.Point.X, to.Point.X));
+					Range = new IntVector2(Math.Min(from.Point.X, to.Point.X), Math.Max(from.Point.X, to.Point.X));
 				}
 				else
 				{
-					Range = new Range<int>(Math.Min(from.Point.Y, to.Point.Y), Math.Max(from.Point.Y, to.Point.Y));
+					Range = new IntVector2(Math.Min(from.Point.Y, to.Point.Y), Math.Max(from.Point.Y, to.Point.Y));
 				}
 			}
 

--- a/GeneralAlgorithms/GeneralAlgorithms.csproj
+++ b/GeneralAlgorithms/GeneralAlgorithms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GraphPlanarityTesting" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="RangeTree" Version="1.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RangeTree" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/MapGeneration.IntegrationTests/MapGeneration.IntegrationTests.csproj
+++ b/MapGeneration.IntegrationTests/MapGeneration.IntegrationTests.csproj
@@ -8,8 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MapGeneration.Interfaces/MapGeneration.Interfaces.csproj
+++ b/MapGeneration.Interfaces/MapGeneration.Interfaces.csproj
@@ -8,7 +8,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeneralAlgorithms\GeneralAlgorithms.csproj" />

--- a/MapGeneration.Tests/MapGeneration.Tests.csproj
+++ b/MapGeneration.Tests/MapGeneration.Tests.csproj
@@ -13,9 +13,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Configuration" />

--- a/MapGeneration/Benchmarks/Benchmark.cs
+++ b/MapGeneration/Benchmarks/Benchmark.cs
@@ -28,7 +28,7 @@
 		{
 			var benchmarkJobs = new List<BenchmarkJob<TMapDescription, TLayout>>();
 			var benchmark = new BenchmarkUtils.Benchmark<BenchmarkJob<TMapDescription, TLayout>, BenchmarkResult>();
-			benchmark.SetConsoleOutput(true);
+			benchmark.SetConsoleOutput(true, true);
 			benchmark.AddFileOutput(namingConvention: NamingConvention.FixedName, filename: filename);
 
 			foreach (var mapDescriptionInfo in mapDescriptions)

--- a/MapGeneration/MapGeneration.csproj
+++ b/MapGeneration/MapGeneration.csproj
@@ -16,9 +16,9 @@
     <Copy SourceFiles="@(GeneratorResources)" DestinationFolder="$(TargetDir)\Resources\%(RecursiveDir)" SkipUnchangedFiles="false" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="BenchmarkUtils" Version="1.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="YamlDotNet" Version="5.3.0" />
+    <PackageReference Include="BenchmarkUtils" Version="1.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeneralAlgorithms\GeneralAlgorithms.csproj" />

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -40,7 +40,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Upgraded referenced nuget packages for:
RangeTree (2.0.1)
Newtonsoft.Json (12.0.3)
NUnit (3.12.0)
NUnit3TestAdapter (3.16.1)
Microsoft.NET.Test.Sdk (16.5.0)
BenchmarkUtils (1.2.2)
YamlDotNet (8.1.0)
Microsoft.CSharp (4.7.0)